### PR TITLE
Remove using in Readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ Here is how to convert an RTF byte array to a plain text string:
 
 ```cs
 using ReasonableRTF;
-using ReasonableRTF.Models;
 using System.IO;
 
 // ...


### PR DESCRIPTION
The usage of ReasonableRTF.Models is wrong for ReasonableRTF. It's correct for ReasonableRTF.Standard because I split some stuff