### PR TITLE
Switch to `Meziantou.Polyfill`, simplify compatibility code, and package xml documentation

### DIFF
--- a/ReasonableRTF/Extensions/ArrayExtension.cs
+++ b/ReasonableRTF/Extensions/ArrayExtension.cs
@@ -1,0 +1,16 @@
+﻿#if NETSTANDARD2_0
+
+namespace System
+{
+    internal static class ArrayExtension
+    {
+        extension(Array)
+        {
+            // The Max Length of an Array
+            // Copy of https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/Array.cs
+            public static int MaxLength => 0X7FFFFFC7;
+        }
+    }
+}
+
+#endif

--- a/ReasonableRTF/Models/GroupStack.cs
+++ b/ReasonableRTF/Models/GroupStack.cs
@@ -30,14 +30,7 @@ namespace ReasonableRTF.Models;
 
 internal sealed class GroupStack
 {
-#if NET8_0_OR_GREATER
     private static readonly int PropertiesLen = Enum.GetValues<Property>().Length;
-#else
-    private static readonly int PropertiesLen = Enum.GetValues(typeof(Property)).Length;
-    // The Max Length of an Array
-    // Copy of https://github.com/dotnet/runtime/blob/main/src/libraries/System.Private.CoreLib/src/System/Array.cs
-    private const int MaxLength = 0X7FFFFFC7;
-#endif
 
     private const int DefaultCapacity = 100;
     private int Capacity;
@@ -76,11 +69,7 @@ internal sealed class GroupStack
     {
         int oldMaxGroups = Capacity;
         int newCapacity = Capacity * 2;
-#if NET8_0_OR_GREATER
         if ((uint)newCapacity > Array.MaxLength) newCapacity = Array.MaxLength;
-#else
-        if ((uint)newCapacity > MaxLength) newCapacity = MaxLength;
-#endif
 
         Capacity = newCapacity;
         Array.Resize(ref _skipDestinations, Capacity);

--- a/ReasonableRTF/ReasonableRTF.csproj
+++ b/ReasonableRTF/ReasonableRTF.csproj
@@ -10,7 +10,9 @@
 		<Version>2026.4.0</Version>
 		<Copyright>Copyright 2024-2026 Brian Tobin</Copyright>
 		<Platforms>AnyCPU;x86;x64</Platforms>
-	</PropertyGroup>
+		<DocumentationFile>bin\$(Configuration)\$(TargetFramework)\$(AssemblyName).xml</DocumentationFile>
+		<NoWarn>$(NoWarn);1591</NoWarn>
+    </PropertyGroup>
 
 	<ItemGroup>
 		<PackageReference Condition="'$(TargetFramework)'=='netstandard2.0'" Include="Nullable" Version="1.3.1">

--- a/ReasonableRTF/ReasonableRTF.csproj
+++ b/ReasonableRTF/ReasonableRTF.csproj
@@ -14,12 +14,22 @@
 		<NoWarn>$(NoWarn);1591</NoWarn>
     </PropertyGroup>
 
-	<ItemGroup>
-		<PackageReference Condition="'$(TargetFramework)'=='netstandard2.0'" Include="Nullable" Version="1.3.1">
+	<PropertyGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
+		<MeziantouPolyfill_IncludedPolyfills>
+			T:System.Diagnostics.CodeAnalysis.DoesNotReturnAttribute;
+			T:System.Diagnostics.CodeAnalysis.MemberNotNullAttribute;
+			T:System.Diagnostics.CodeAnalysis.NotNullWhenAttribute;
+			M:System.Enum.GetValues``1;
+			M:System.UInt16.TryParse(System.ReadOnlySpan{System.Char},System.Globalization.NumberStyles,System.IFormatProvider,System.UInt16@);
+		</MeziantouPolyfill_IncludedPolyfills>
+	</PropertyGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
+		<PackageReference Include="Meziantou.Polyfill" Version="1.0.105">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Condition="'$(TargetFramework)'=='netstandard2.0'" Include="System.Text.Encoding.CodePages" Version="9.0.10" />
+		<PackageReference Include="System.Text.Encoding.CodePages" Version="9.0.10" />
 	</ItemGroup>
 
 </Project>

--- a/ReasonableRTF/RtfToTextConverter.cs
+++ b/ReasonableRTF/RtfToTextConverter.cs
@@ -3411,17 +3411,10 @@ public sealed class RtfToTextConverter
         if (numIsHex)
         {
             ReadOnlySpan<char> span = new(_fldinstSymbolNumber.ItemsArray, 0, _fldinstSymbolNumber.Count);
-#if NET8_0_OR_GREATER
             if (!ushort.TryParse(span,
                     NumberStyles.HexNumber,
                     NumberFormatInfo.InvariantInfo,
                     out param))
-#else
-            if (!ushort.TryParse(span.ToString(),
-                    NumberStyles.HexNumber,
-                    NumberFormatInfo.InvariantInfo,
-                    out param))
-#endif
             {
                 return RewindAndSkipGroup();
             }


### PR DESCRIPTION
This PR replaces the `Nullable` package with `Meziantou.Polyfill` for `netstandard2.0`, explicitly configures the polyfills to include, simplifies a few target-framework-specific code paths, and keep XML documentation generation enabled so the NuGet package includes docs.

### What changed
- Replaced `Nullable` with `Meziantou.Polyfill`
- Explicitly selected the polyfills to include instead of relying on the default set
- Added support for:
  - enum value retrieval
  - `ushort` parsing from `ReadOnlySpan<char>`
  - `Array.MaxLength` on `netstandard2.0`
- Removed framework-specific branching in a couple of code paths
- Kept XML doc output enabled for the package

### Why
This makes the compatibility layer more intentional and easier to maintain:
- fewer unnecessary polyfills
- more room to add only the helpers the codebase actually needs
- cleaner code with fewer conditional compilation checks

### Notes
These changes are mostly about portability and package quality, but they also simplify the codebase by reducing framework-specific branching.