### PR TITLE
Centralize package versions, simplify polyfills, and remove hardcoded benchmark paths

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,11 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+    <CentralPackageVersionOverrideEnabled>false</CentralPackageVersionOverrideEnabled>
+  </PropertyGroup>
+  <ItemGroup>
+      <PackageVersion Include="BenchmarkDotNet" Version="0.15.8" />
+      <PackageVersion Include="Meziantou.Polyfill" Version="1.0.105" />
+      <PackageVersion Include="System.Text.Encoding.CodePages" Version="9.0.10" />
+  </ItemGroup>
+</Project>

--- a/ReasonableRTF/ReasonableRTF.csproj
+++ b/ReasonableRTF/ReasonableRTF.csproj
@@ -25,11 +25,11 @@
 	</PropertyGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)'=='netstandard2.0'">
-		<PackageReference Include="Meziantou.Polyfill" Version="1.0.105">
+		<PackageReference Include="Meziantou.Polyfill">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="System.Text.Encoding.CodePages" Version="9.0.10" />
+		<PackageReference Include="System.Text.Encoding.CodePages"/>
 	</ItemGroup>
 
 </Project>

--- a/ReasonableRTF_Benchmark/FileSetLocator.cs
+++ b/ReasonableRTF_Benchmark/FileSetLocator.cs
@@ -1,0 +1,35 @@
+﻿using System.Runtime.CompilerServices;
+
+namespace ReasonableRTF_Benchmark;
+
+internal static class FileSetLocator
+{
+    private const string RtfFullSetDir = "RTF_Test_Set_Full";
+    private const string RtfSmallSetDir = "RTF_Test_Set_Small";
+
+    private const string DataSetLocation = @"ReasonableRTF_TestApp\Data";
+
+    public static string GetFileSet(FileSetType type)
+    {
+        string currentPath = GetCurrentPath();
+        string directory = type switch
+        {
+            FileSetType.Full => RtfFullSetDir,
+            FileSetType.Small => RtfSmallSetDir,
+            _ => throw new ArgumentOutOfRangeException(nameof(type), type, null)
+        };
+
+        return Path.GetFullPath(Path.Combine(currentPath, "..", "..", DataSetLocation, directory));
+    }
+
+    private static string GetCurrentPath([CallerFilePath] string callerFilePath = "")
+    {
+        return callerFilePath;
+    }
+}
+
+public enum FileSetType
+{
+    Full,
+    Small
+}

--- a/ReasonableRTF_Benchmark/Program.cs
+++ b/ReasonableRTF_Benchmark/Program.cs
@@ -7,10 +7,6 @@ namespace ReasonableRTF_Benchmark;
 
 public class Test
 {
-    // Believe it or not you have to put your exact actual path here because BenchmarkDotNet causes every kind of
-    // app startup path getting method in the ENTIRE UNIVERSE to not work. Argh.
-    private const string TestDataDir = @"C:\Users\Brian\source\repos\ReasonableRTF\ReasonableRTF_TestApp\Data";
-
     private readonly MemoryStream[] _fullSetMemStreams;
     private readonly MemoryStream[] _smallSetMemStreams;
     private readonly MemoryStream[] _fullSetMemStreams_Chunked;
@@ -20,9 +16,9 @@ public class Test
     private readonly RichTextBox _rtfBox;
     private readonly RtfToTextConverter _rtfConverter;
 
-    private MemoryStream[] GetStuff_RichTextBox(bool small)
+    private static MemoryStream[] GetStuff_RichTextBox(FileSetType type)
     {
-        string[] rtfFiles = Directory.GetFiles(GetRtfSetDir(small));
+        string[] rtfFiles = Directory.GetFiles(FileSetLocator.GetFileSet(type));
         MemoryStream[] memStreams = new MemoryStream[rtfFiles.Length];
 
         for (int i = 0; i < rtfFiles.Length; i++)
@@ -37,9 +33,9 @@ public class Test
         return memStreams;
     }
 
-    private byte[][] GetStuff_Custom(bool small)
+    private static byte[][] GetStuff_Custom(FileSetType type)
     {
-        string[] rtfFiles = Directory.GetFiles(GetRtfSetDir(small));
+        string[] rtfFiles = Directory.GetFiles(FileSetLocator.GetFileSet(type));
 
         byte[][] byteArrays = new byte[rtfFiles.Length][];
 
@@ -55,9 +51,9 @@ public class Test
         return byteArrays;
     }
 
-    private MemoryStream[] GetStuff_Custom_Chunked(bool small)
+    private static MemoryStream[] GetStuff_Custom_Chunked(FileSetType type)
     {
-        string[] rtfFiles = Directory.GetFiles(GetRtfSetDir(small));
+        string[] rtfFiles = Directory.GetFiles(FileSetLocator.GetFileSet(type));
 
         MemoryStream[] memoryStreams = new MemoryStream[rtfFiles.Length];
 
@@ -75,26 +71,17 @@ public class Test
 
     public Test()
     {
-        _fullSetMemStreams = GetStuff_RichTextBox(small: false);
-        _smallSetMemStreams = GetStuff_RichTextBox(small: true);
+        _fullSetMemStreams = GetStuff_RichTextBox(FileSetType.Full);
+        _smallSetMemStreams = GetStuff_RichTextBox(FileSetType.Small);
 
-        _fullSetByteArrays = GetStuff_Custom(small: false);
-        _smallSetByteArrays = GetStuff_Custom(small: true);
+        _fullSetByteArrays = GetStuff_Custom(FileSetType.Full);
+        _smallSetByteArrays = GetStuff_Custom(FileSetType.Small);
 
-        _fullSetMemStreams_Chunked = GetStuff_Custom_Chunked(small: false);
-        _smallSetMemStreams_Chunked = GetStuff_Custom_Chunked(small: true);
+        _fullSetMemStreams_Chunked = GetStuff_Custom_Chunked(FileSetType.Full);
+        _smallSetMemStreams_Chunked = GetStuff_Custom_Chunked(FileSetType.Small);
 
         _rtfBox = new RichTextBox();
         _rtfConverter = new RtfToTextConverter();
-    }
-
-    private const string _rtfFullSetDir = "RTF_Test_Set_Full";
-    private const string _rtfSmallSetDir = "RTF_Test_Set_Small";
-
-    private string GetRtfSetDir(bool small)
-    {
-        string dir = small ? _rtfSmallSetDir : _rtfFullSetDir;
-        return Path.Combine(TestDataDir, dir);
     }
 
     [Benchmark]

--- a/ReasonableRTF_Benchmark/ReasonableRTF_Benchmark.csproj
+++ b/ReasonableRTF_Benchmark/ReasonableRTF_Benchmark.csproj
@@ -17,7 +17,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="BenchmarkDotNet" Version="0.15.8" />
+		<PackageReference Include="BenchmarkDotNet"/>
 	</ItemGroup>
 
 	<ItemGroup>

--- a/ReasonableRTF_TestApp/ReasonableRTF_TestApp.csproj
+++ b/ReasonableRTF_TestApp/ReasonableRTF_TestApp.csproj
@@ -36,7 +36,7 @@
 	</ItemGroup>
 
 	<ItemGroup Condition="'$(TargetFramework)'=='net48'">
-		<PackageReference Include="Meziantou.Polyfill" Version="1.0.105">
+		<PackageReference Include="Meziantou.Polyfill">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>

--- a/ReasonableRTF_TestApp/ReasonableRTF_TestApp.csproj
+++ b/ReasonableRTF_TestApp/ReasonableRTF_TestApp.csproj
@@ -13,23 +13,33 @@
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)'=='Release_Framework'">
-	  <Optimize>True</Optimize>
+		<Optimize>True</Optimize>
 	</PropertyGroup>
 
-	<ItemGroup>
-	  <PackageReference Condition="'$(TargetFrameworks)'=='net48'" Include="PolySharp" Version="1.15.0">
-	    <PrivateAssets>all</PrivateAssets>
-	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-	  </PackageReference>
-	</ItemGroup>
+	<PropertyGroup Condition="'$(TargetFramework)'=='net48'">
+		<MeziantouPolyfill_IncludedPolyfills>
+			T:System.Diagnostics.CodeAnalysis.DoesNotReturnAttribute;
+			T:System.Diagnostics.CodeAnalysis.MemberNotNullWhenAttribute;
+			T:System.Diagnostics.CodeAnalysis.NotNullWhenAttribute;
+			T:System.Index;
+			T:System.Range;
+			T:System.Runtime.CompilerServices.IsExternalInit;
+		</MeziantouPolyfill_IncludedPolyfills>
+	</PropertyGroup>
 
 	<ItemGroup>
 		<ProjectReference Include="..\ReasonableRTF\ReasonableRTF.csproj" />
 	</ItemGroup>
 
-	<ItemGroup>
-	  <Reference Condition="'$(TargetFrameworks)'=='net48'" Include="System.IO.Compression" />
+	<ItemGroup Condition="'$(TargetFramework)'=='net48'">
+		<Reference Include="System.IO.Compression" />
+	</ItemGroup>
+
+	<ItemGroup Condition="'$(TargetFramework)'=='net48'">
+		<PackageReference Include="Meziantou.Polyfill" Version="1.0.105">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
 	</ItemGroup>
 
 </Project>
-


### PR DESCRIPTION
### Summary
This PR centralizes package version management, switches the .NET Framework test app to use `Meziantou.Polyfill`, and removes the hardcoded benchmark dataset path by resolving test files dynamically.

### What changed
- Added `Directory.Packages.props` to manage package versions centrally
- Removed explicit package version declarations from project files
- Switched the test app’s `net48` support to `Meziantou.Polyfill`
- Kept only the polyfills the app actually needs
- Reworked benchmark dataset lookup to avoid a hardcoded absolute path
- Added a reusable file-set locator for the benchmark project

### Why
These changes make the solution easier to maintain:
- package versions are now defined in one place
- the compatibility setup is simpler and more consistent
- benchmark setup is no longer tied to a machine-specific path
- project configuration is cleaner overall

### Notes
The main focus here is maintainability and portability. The runtime behavior should remain the same, but the setup is now less brittle and easier to update.